### PR TITLE
Use plan slug as instance-type for Packet

### DIFF
--- a/cloud/providers/packet/instances.go
+++ b/cloud/providers/packet/instances.go
@@ -90,7 +90,7 @@ func (i *instances) InstanceType(nodeName types.NodeName) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return device.Plan.Name, nil
+	return device.Plan.Slug, nil
 }
 
 func (i *instances) InstanceTypeByProviderID(providerID string) (string, error) {
@@ -102,7 +102,7 @@ func (i *instances) InstanceTypeByProviderID(providerID string) (string, error) 
 	if err != nil {
 		return "", err
 	}
-	return device.Plan.Name, nil
+	return device.Plan.Slug, nil
 }
 
 func (i *instances) AddSSHKeyToAllInstances(user string, keyData []byte) error {


### PR DESCRIPTION
```
I1121 17:57:36.672674       1 node_controller.go:323] Adding node label from cloud provider: beta.kubernetes.io/instance-type=Type 0
I1121 17:57:36.848327       1 node_controller.go:350] Adding node label from cloud provider: failure-domain.beta.kubernetes.io/region=Parsippany, NJ
I1121 17:57:38.193088       1 node_controller.go:323] Adding node label from cloud provider: beta.kubernetes.io/instance-type=Type 0
I1121 17:57:38.355596       1 node_controller.go:350] Adding node label from cloud provider: failure-domain.beta.kubernetes.io/region=Parsippany, NJ
E1121 17:57:38.360900       1 node_controller.go:367] Node "packet-master" is invalid: [metadata.labels: Invalid value: "Type 0": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'), metadata.labels: Invalid value: "Parsippany, NJ": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')]

```